### PR TITLE
20230906 功能更新

### DIFF
--- a/HTMACat/catkit/gen/utils/__init__.py
+++ b/HTMACat/catkit/gen/utils/__init__.py
@@ -9,6 +9,7 @@ from .utilities import (running_mean, to_gratoms, get_atomic_numbers,
                         list_gcd)
 from .utils_mdnm import (mol_to_graph,
                          solve_normal_vector_linearsvc,
+                         solve_normal_vector_pca,
                          solve_principle_axe_pca,
                          Check_treatable__HTMATver,
                          Gen_conn_mole)
@@ -36,6 +37,7 @@ __all__ = ['get_voronoi_neighbors',
            'list_gcd',
            'mol_to_graph',
            'solve_normal_vector_linearsvc',
+           'solve_normal_vector_pca',
            'solve_principle_axe_pca',
            'Check_treatable__HTMATver',
            'Gen_conn_mole']

--- a/HTMACat/model/Substrate.py
+++ b/HTMACat/model/Substrate.py
@@ -102,12 +102,13 @@ class Bulk:
 
 
 class Slab(Structure):
-    def __init__(self, in_bulk=Bulk(), facet="100", layers=4):
+    def __init__(self, in_bulk=Bulk(), facet="100", layers=4, layers_relax=2):
         self.bulk = in_bulk
         self.file = None
         self.facet = facet
         self.property = {}
         self.layers = layers
+        self.layers_relax = layers_relax
         if "p1" not in self.property or "p1_symb" not in self.property:
             self.property["p1"] = []
             self.property["p1_symb"] = []
@@ -129,6 +130,9 @@ class Slab(Structure):
 
     def get_layers(self):
         return self.layers
+    
+    def get_layers_relax(self):
+        return self.layers_relax
 
     def out_file_name(self):
         mname = self.bulk.get_main_element()
@@ -180,12 +184,13 @@ class Slab(Structure):
         mbulk = self.bulk.construct()
         supercell = self.bulk.get_supercell()
         layers = self.get_layers()
+        layers_relax = self.get_layers_relax()
         ##### generate the surfaces #####
         gen = SlabGenerator(
             mbulk,
             miller_index=miller_index,
             layers=layers,
-            fixed=2,
+            fixed=layers-layers_relax,
             layer_type="trim",
             vacuum=8,
             standardize_bulk=True,
@@ -247,7 +252,7 @@ class Slab(Structure):
         bulk_init_dict = get_new_dict(bulk_list, init_dict)
         in_bulk = Bulk(**bulk_init_dict)
         # get the parameters for slab initialization
-        slab_list = ['facet','layers']
+        slab_list = ['facet','layers','layers_relax']
         slab_init_dict = get_new_dict(slab_list, init_dict)
 
         return cls(in_bulk, **slab_init_dict)
@@ -261,7 +266,7 @@ class Slab(Structure):
             return []
         substrates = []
         # get the parameters for struct initialization
-        struct_list = ['element','lattice_type','lattice_constant','supercell','layers']
+        struct_list = ['element','lattice_type','lattice_constant','supercell','layers','layers_relax']
         struct_init_dict = get_new_dict(struct_list,struct_Info)
         # get the parameters for dope and surface initialization
         dope_system = struct_Info["dope"]


### PR DESCRIPTION
在ads、coads各行末尾增加了settings字典，用以针对各个物种的吸附单独进行调整，并容纳后续所有的功能扩展
![(Z O(QY6E2RK1N6 $NDO)8D](https://github.com/materialssimulation/HTMACat-kit/assets/17785207/0adf781a-808c-4b87-ab29-9d558e49b3ef)

settings中的参数：
- direction   (value = 'bond_atom' or 'asphericity')
    选择确定物种“吸附矢量”的方法（2种），默认为bond_atom
- rotation   (value = 'vnn')
    选择物种在xoy平面内绕Z轴旋转以增大间隔的方法（目前仅1种），默认跳过此操作
- coads_list   (value = [lb: float, ub: float])
    对共吸附生效，规定两吸附物种之间距离的上下限
- site_locate_ads1   (value = [x: float, y: float])（*尚未实现，用以提升NEB初末态建模一致性）
    指定一个坐标，使第一个物种倾向于在最靠近此坐标的可吸附位点上吸附（各类位点的多个等价位点中选择一个，如Cu111表面应有top、bridge、hollow-a、hollow-b共4个最靠近的位点被选取）